### PR TITLE
Add interactive image map plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ npm run build
 
 After building, copy the contents of `/dist` into your Obsidian vault’s `.obsidian/plugins/` folder.
 
+### ✨ Usage
+
+Add an HTML image tag with a `data-overlay` attribute pointing to an SVG file. The plugin wraps the image in a container and overlays the SVG so you can animate or style it via CSS.
+
+```markdown
+<!-- example -->
+<img src="my-diagram.png" data-overlay="my-overlay.svg" />
+```
+
+Any vectors in `my-overlay.svg` are positioned on top of the image. You can add animations or interactions using regular CSS selectors targeting `.image-map-overlay`.
+
 ---
 
 ## 🧱 Folder Structure

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,10 @@
+{
+  "id": "image-map",
+  "name": "Image Map",
+  "version": "0.1.0",
+  "minAppVersion": "0.15.0",
+  "description": "Overlay images with interactive SVG vectors.",
+  "author": "PtiCalin",
+  "authorUrl": "https://github.com/your-username",
+  "isDesktopOnly": false
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "obsidian-image-map-plugin",
+  "version": "0.1.0",
+  "description": "Overlay images with interactive SVG vectors in Obsidian notes.",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "devDependencies": {
+    "obsidian": "^1.0.0",
+    "typescript": "^4.9.5"
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,44 @@
+import { Plugin } from 'obsidian';
+
+export default class ImageMapPlugin extends Plugin {
+  async onload() {
+    this.registerMarkdownPostProcessor(async (el, ctx) => {
+      const images = el.querySelectorAll<HTMLImageElement>('img[data-overlay]');
+      for (const img of Array.from(images)) {
+        const overlay = img.getAttribute('data-overlay');
+        if (!overlay) continue;
+        const file = this.app.metadataCache.getFirstLinkpathDest(overlay, ctx.sourcePath);
+        if (!file) continue;
+        try {
+          const svg = await this.app.vault.read(file);
+          const wrapper = createDiv({ cls: 'image-map-container' });
+          img.parentElement?.insertBefore(wrapper, img);
+          wrapper.appendChild(img);
+
+          const overlayEl = createDiv({ cls: 'image-map-overlay' });
+          overlayEl.innerHTML = svg;
+          wrapper.appendChild(overlayEl);
+        } catch (err) {
+          console.error('Image Map Plugin: Cannot load overlay', overlay, err);
+        }
+      }
+    });
+
+    this.injectStyles();
+  }
+
+  injectStyles() {
+    const style = document.createElement('style');
+    style.id = 'image-map-style';
+    style.textContent = `
+.image-map-container { position: relative; display: inline-block; }
+.image-map-container img { display: block; }
+.image-map-overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; }
+`;
+    document.head.appendChild(style);
+  }
+
+  onunload() {
+    document.getElementById('image-map-style')?.remove();
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,15 @@
+.image-map-container {
+  position: relative;
+  display: inline-block;
+}
+.image-map-container img {
+  display: block;
+}
+.image-map-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- create TypeScript plugin skeleton
- allow images with `data-overlay` attribute to show SVG overlay
- document how to use the plugin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842154ed86083229304e4e35cd2657f