### PR TITLE
Add setup script and codex instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ npm install
 npm run build
 ```
 
+### ⚙️ Automated Setup (Codex)
+
+If you're running this repository in a Codex environment, place the commands
+above in a `setup.sh` script at the project root:
+
+```bash
+#!/usr/bin/env bash
+npm install
+npm run build
+```
+
+Make the script executable with `chmod +x setup.sh`. Codex will run it
+automatically when the workspace starts. If network access is restricted,
+set `CODEX_ENABLE_NETWORK=1` or request outbound access so `npm install` can
+download packages.
+
 After building, copy the contents of `/dist` into your Obsidian vault’s `.obsidian/plugins/` folder.
 
 ### ✨ Usage

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Setup script for the Image Map plugin
+# It installs dependencies and builds the project.
+set -euo pipefail
+
+# Optional: request network access in Codex environments
+if [[ -n "${CODEX_ENABLE_NETWORK:-}" ]]; then
+  if command -v codex >/dev/null 2>&1; then
+    codex configure network enable || true
+  fi
+fi
+
+npm install
+npm run build
+


### PR DESCRIPTION
## Summary
- create `setup.sh` to install and build the plugin
- document automated setup in Codex environments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845d3f5bc9c832287b92f152cb90b2f