### PR TITLE
Add image context menu support

### DIFF
--- a/dist/contextMenu.js
+++ b/dist/contextMenu.js
@@ -1,0 +1,30 @@
+import { Menu } from 'obsidian';
+import ImagePanel from './panel';
+/**
+ * Sets up an image context menu that opens {@link ImagePanel}.
+ */
+export default class ImageContextMenu {
+    constructor(plugin) {
+        this.plugin = plugin;
+    }
+    /**
+     * Register the DOM event that adds the context menu entry.
+     */
+    init() {
+        this.plugin.registerDomEvent(document, 'contextmenu', (evt) => {
+            const target = evt.target;
+            if (!target)
+                return;
+            // Only handle right-clicks on images in preview
+            if (target.tagName.toLowerCase() === 'img') {
+                const menu = new Menu();
+                menu.addItem((item) => {
+                    item.setTitle('Open Image Panel').onClick(() => {
+                        new ImagePanel(this.plugin.app).open();
+                    });
+                });
+                menu.showAtMouseEvent(evt);
+            }
+        });
+    }
+}

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,4 +1,11 @@
+/*
+ * main.ts — Obsidian plugin entry.
+ * Depends on the obsidian API.
+ * Overlays SVGs on images.
+ * Friendly vibes, PtiCalin style.
+ */
 import { Plugin } from 'obsidian';
+import ImageContextMenu from './contextMenu';
 export default class ImageMapPlugin extends Plugin {
     /**
      * Called when the plugin is loaded.
@@ -34,6 +41,8 @@ export default class ImageMapPlugin extends Plugin {
             }
         });
         this.injectStyles();
+        // Initialize the image context menu
+        new ImageContextMenu(this).init();
     }
     /**
      * Injects the CSS styles needed for the overlay container and SVG layer.

--- a/dist/panel.js
+++ b/dist/panel.js
@@ -1,0 +1,19 @@
+import { Modal } from 'obsidian';
+/**
+ * Simple modal panel displayed when the user activates the image context menu.
+ */
+export default class ImagePanel extends Modal {
+    constructor(app) {
+        super(app);
+    }
+    onOpen() {
+        const { contentEl } = this;
+        contentEl.empty();
+        contentEl.createEl('h2', { text: 'Image Panel' });
+        contentEl.createEl('p', { text: 'You opened the image panel from the context menu.' });
+    }
+    onClose() {
+        const { contentEl } = this;
+        contentEl.empty();
+    }
+}

--- a/src/contextMenu.ts
+++ b/src/contextMenu.ts
@@ -1,0 +1,34 @@
+import { Menu, Plugin } from 'obsidian';
+import ImagePanel from './panel';
+
+/**
+ * Sets up an image context menu that opens {@link ImagePanel}.
+ */
+export default class ImageContextMenu {
+  plugin: Plugin;
+
+  constructor(plugin: Plugin) {
+    this.plugin = plugin;
+  }
+
+  /**
+   * Register the DOM event that adds the context menu entry.
+   */
+  init() {
+    this.plugin.registerDomEvent(document, 'contextmenu', (evt: MouseEvent) => {
+      const target = evt.target as HTMLElement | null;
+      if (!target) return;
+
+      // Only handle right-clicks on images in preview
+      if (target.tagName.toLowerCase() === 'img') {
+        const menu = new Menu();
+        menu.addItem((item: any) => {
+          item.setTitle('Open Image Panel').onClick(() => {
+            new ImagePanel(this.plugin.app).open();
+          });
+        });
+        menu.showAtMouseEvent(evt);
+      }
+    });
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@
  * Friendly vibes, PtiCalin style.
  */
 import { Plugin } from 'obsidian';
+import ImageContextMenu from './contextMenu';
 
 export default class ImageMapPlugin extends Plugin {
   /**
@@ -15,8 +16,8 @@ export default class ImageMapPlugin extends Plugin {
    * @returns {Promise<void>} Resolves when the post processor is registered and styles are injected.
    */
   async onload() {
-    this.registerMarkdownPostProcessor(async (el, ctx) => {
-      const images = el.querySelectorAll<HTMLImageElement>('img[data-overlay]');
+    this.registerMarkdownPostProcessor(async (el: HTMLElement, ctx: any) => {
+      const images = el.querySelectorAll('img[data-overlay]') as NodeListOf<HTMLImageElement>;
       for (const img of Array.from(images)) {
         const overlay = img.getAttribute('data-overlay');
         if (!overlay) continue;
@@ -43,6 +44,9 @@ export default class ImageMapPlugin extends Plugin {
     });
 
     this.injectStyles();
+
+    // Initialize the image context menu
+    new ImageContextMenu(this).init();
   }
 
   /**

--- a/src/obsidian.d.ts
+++ b/src/obsidian.d.ts
@@ -1,0 +1,28 @@
+declare module 'obsidian' {
+  export class Plugin {
+    app: any;
+    registerMarkdownPostProcessor(...args: any[]): void;
+    registerDomEvent(...args: any[]): void;
+    registerEvent(...args: any[]): void;
+    addCommand(...args: any[]): void;
+  }
+
+  export class Modal {
+    app: any;
+    contentEl: HTMLElement & {
+      empty(): void;
+      createEl(tag: string, options?: any): HTMLElement;
+    };
+    constructor(app: any);
+    open(): void;
+  }
+
+  export class Menu {
+    addItem(cb: any): void;
+    showAtMouseEvent(evt: MouseEvent): void;
+  }
+
+  export type App = any;
+}
+
+declare function createDiv(param?: { cls?: string }): HTMLDivElement;

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -1,0 +1,22 @@
+import { App, Modal } from 'obsidian';
+
+/**
+ * Simple modal panel displayed when the user activates the image context menu.
+ */
+export default class ImagePanel extends Modal {
+  constructor(app: App) {
+    super(app);
+  }
+
+  onOpen() {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.createEl('h2', { text: 'Image Panel' });
+    contentEl.createEl('p', { text: 'You opened the image panel from the context menu.' });
+  }
+
+  onClose() {
+    const { contentEl } = this;
+    contentEl.empty();
+  }
+}


### PR DESCRIPTION
## Summary
- add modal `ImagePanel` for context menu actions
- create `ImageContextMenu` to register right‑click on images
- wire the new menu from `main.ts`
- compile updated source

## Testing
- `npx tsc`