### PR TITLE
Add coordinate-based overlay support

### DIFF
--- a/dist/imageMap.js
+++ b/dist/imageMap.js
@@ -1,0 +1,56 @@
+/**
+ * Parse coordinates from either data attributes or frontmatter.
+ * If the image contains a `data-coordinates` JSON string, it is used.
+ * Otherwise, if a `data-map` key is present and matching data exists in
+ * frontmatter under `imageMaps`, that data is returned.
+ */
+export function parseCoordinates(img, frontmatter) {
+    const json = img.getAttribute('data-coordinates');
+    if (json) {
+        try {
+            return JSON.parse(json);
+        }
+        catch (e) {
+            console.error('Invalid data-coordinates JSON', e);
+        }
+    }
+    const key = img.getAttribute('data-map');
+    if (key && frontmatter && frontmatter.imageMaps && frontmatter.imageMaps[key]) {
+        return frontmatter.imageMaps[key];
+    }
+    return null;
+}
+const NS = 'http://www.w3.org/2000/svg';
+export function createPolygon(points) {
+    const el = document.createElementNS(NS, 'polygon');
+    el.setAttribute('points', points);
+    return el;
+}
+export function createRect(x, y, width, height) {
+    const el = document.createElementNS(NS, 'rect');
+    el.setAttribute('x', String(x));
+    el.setAttribute('y', String(y));
+    el.setAttribute('width', String(width));
+    el.setAttribute('height', String(height));
+    return el;
+}
+export function createEllipse(cx, cy, rx, ry) {
+    const el = document.createElementNS(NS, 'ellipse');
+    el.setAttribute('cx', String(cx));
+    el.setAttribute('cy', String(cy));
+    el.setAttribute('rx', String(rx));
+    el.setAttribute('ry', String(ry));
+    return el;
+}
+/**
+ * Build an SVG overlay from a set of shape coordinates.
+ */
+export function shapesToSVG(def) {
+    const svg = document.createElementNS(NS, 'svg');
+    svg.setAttribute('viewBox', '0 0 100 100');
+    svg.setAttribute('preserveAspectRatio', 'none');
+    def.polygons?.forEach((pts) => svg.appendChild(createPolygon(pts)));
+    def.rects?.forEach(([x, y, w, h]) => svg.appendChild(createRect(x, y, w, h)));
+    def.ellipses?.forEach(([cx, cy, rx, ry]) => svg.appendChild(createEllipse(cx, cy, rx, ry)));
+    return svg;
+}

--- a/dist/main.js
+++ b/dist/main.js
@@ -6,6 +6,7 @@
  */
 import { Plugin } from 'obsidian';
 import ImageContextMenu from './contextMenu';
+import { parseCoordinates, shapesToSVG, } from './imageMap';
 export default class ImageMapPlugin extends Plugin {
     /**
      * Called when the plugin is loaded.
@@ -16,28 +17,35 @@ export default class ImageMapPlugin extends Plugin {
      */
     async onload() {
         this.registerMarkdownPostProcessor(async (el, ctx) => {
-            const images = el.querySelectorAll('img[data-overlay]');
+            const images = el.querySelectorAll('img');
             for (const img of Array.from(images)) {
                 const overlay = img.getAttribute('data-overlay');
-                if (!overlay)
-                    continue;
-                const file = this.app.metadataCache.getFirstLinkpathDest(overlay, ctx.sourcePath);
-                if (!file)
-                    continue;
-                try {
-                    const svg = await this.app.vault.read(file);
-                    const wrapper = createDiv({ cls: 'image-map-container' });
-                    img.parentElement?.insertBefore(wrapper, img);
-                    wrapper.appendChild(img);
-                    const overlayEl = createDiv({ cls: 'image-map-overlay' });
-                    overlayEl.innerHTML = svg;
-                    wrapper.appendChild(overlayEl);
+                let externalSvg = '';
+                if (overlay) {
+                    const file = this.app.metadataCache.getFirstLinkpathDest(overlay, ctx.sourcePath);
+                    if (file) {
+                        try {
+                            externalSvg = await this.app.vault.read(file);
+                        }
+                        catch (err) {
+                            console.error(`❌ Unable to load overlay "${overlay}". ` +
+                                'Please verify the path and ensure the SVG exists. ' +
+                                'Reload Obsidian if the issue persists.', err);
+                        }
+                    }
                 }
-                catch (err) {
-                    console.error(`❌ Unable to load overlay "${overlay}". ` +
-                        'Please verify the path and ensure the SVG exists. ' +
-                        'Reload Obsidian if the issue persists.', err);
-                }
+                const coords = parseCoordinates(img, ctx.frontmatter);
+                if (!externalSvg && !coords)
+                    continue;
+                const wrapper = createDiv({ cls: 'image-map-container' });
+                img.parentElement?.insertBefore(wrapper, img);
+                wrapper.appendChild(img);
+                const overlayEl = createDiv({ cls: 'image-map-overlay' });
+                if (externalSvg)
+                    overlayEl.innerHTML = externalSvg;
+                if (coords)
+                    overlayEl.appendChild(shapesToSVG(coords));
+                wrapper.appendChild(overlayEl);
             }
         });
         this.injectStyles();

--- a/src/imageMap.ts
+++ b/src/imageMap.ts
@@ -1,0 +1,83 @@
+export interface ShapeCoords {
+  polygons?: string[];
+  rects?: [number, number, number, number][];
+  ellipses?: [number, number, number, number][];
+}
+
+/**
+ * Parse coordinates from either data attributes or frontmatter.
+ * If the image contains a `data-coordinates` JSON string, it is used.
+ * Otherwise, if a `data-map` key is present and matching data exists in
+ * frontmatter under `imageMaps`, that data is returned.
+ */
+export function parseCoordinates(
+  img: HTMLElement,
+  frontmatter?: any,
+): ShapeCoords | null {
+  const json = img.getAttribute('data-coordinates');
+  if (json) {
+    try {
+      return JSON.parse(json) as ShapeCoords;
+    } catch (e) {
+      console.error('Invalid data-coordinates JSON', e);
+    }
+  }
+  const key = img.getAttribute('data-map');
+  if (key && frontmatter && frontmatter.imageMaps && frontmatter.imageMaps[key]) {
+    return frontmatter.imageMaps[key] as ShapeCoords;
+  }
+  return null;
+}
+
+const NS = 'http://www.w3.org/2000/svg';
+
+export function createPolygon(points: string): SVGPolygonElement {
+  const el = document.createElementNS(NS, 'polygon');
+  el.setAttribute('points', points);
+  return el;
+}
+
+export function createRect(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): SVGRectElement {
+  const el = document.createElementNS(NS, 'rect');
+  el.setAttribute('x', String(x));
+  el.setAttribute('y', String(y));
+  el.setAttribute('width', String(width));
+  el.setAttribute('height', String(height));
+  return el;
+}
+
+export function createEllipse(
+  cx: number,
+  cy: number,
+  rx: number,
+  ry: number,
+): SVGEllipseElement {
+  const el = document.createElementNS(NS, 'ellipse');
+  el.setAttribute('cx', String(cx));
+  el.setAttribute('cy', String(cy));
+  el.setAttribute('rx', String(rx));
+  el.setAttribute('ry', String(ry));
+  return el;
+}
+
+/**
+ * Build an SVG overlay from a set of shape coordinates.
+ */
+export function shapesToSVG(def: ShapeCoords): SVGSVGElement {
+  const svg = document.createElementNS(NS, 'svg');
+  svg.setAttribute('viewBox', '0 0 100 100');
+  svg.setAttribute('preserveAspectRatio', 'none');
+
+  def.polygons?.forEach((pts) => svg.appendChild(createPolygon(pts)));
+  def.rects?.forEach(([x, y, w, h]) => svg.appendChild(createRect(x, y, w, h)));
+  def.ellipses?.forEach(([cx, cy, rx, ry]) =>
+    svg.appendChild(createEllipse(cx, cy, rx, ry)),
+  );
+
+  return svg;
+}


### PR DESCRIPTION
## Summary
- parse coordinate shapes from front matter or data attributes
- generate polygon, rect and ellipse SVGs from stored coordinates
- overlay external SVGs and generated shapes on images

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68460895b3648322b2500a4c626355e3