### PR TITLE
Add image-map-shape class to overlay shapes

### DIFF
--- a/dist/imageMap.js
+++ b/dist/imageMap.js
@@ -49,8 +49,20 @@ export function shapesToSVG(def) {
     const svg = document.createElementNS(NS, 'svg');
     svg.setAttribute('viewBox', '0 0 100 100');
     svg.setAttribute('preserveAspectRatio', 'none');
-    def.polygons?.forEach((pts) => svg.appendChild(createPolygon(pts)));
-    def.rects?.forEach(([x, y, w, h]) => svg.appendChild(createRect(x, y, w, h)));
-    def.ellipses?.forEach(([cx, cy, rx, ry]) => svg.appendChild(createEllipse(cx, cy, rx, ry)));
+    def.polygons?.forEach((pts) => {
+        const poly = createPolygon(pts);
+        poly.classList.add('image-map-shape');
+        svg.appendChild(poly);
+    });
+    def.rects?.forEach(([x, y, w, h]) => {
+        const rect = createRect(x, y, w, h);
+        rect.classList.add('image-map-shape');
+        svg.appendChild(rect);
+    });
+    def.ellipses?.forEach(([cx, cy, rx, ry]) => {
+        const ell = createEllipse(cx, cy, rx, ry);
+        ell.classList.add('image-map-shape');
+        svg.appendChild(ell);
+    });
     return svg;
 }

--- a/src/imageMap.ts
+++ b/src/imageMap.ts
@@ -73,11 +73,23 @@ export function shapesToSVG(def: ShapeCoords): SVGSVGElement {
   svg.setAttribute('viewBox', '0 0 100 100');
   svg.setAttribute('preserveAspectRatio', 'none');
 
-  def.polygons?.forEach((pts) => svg.appendChild(createPolygon(pts)));
-  def.rects?.forEach(([x, y, w, h]) => svg.appendChild(createRect(x, y, w, h)));
-  def.ellipses?.forEach(([cx, cy, rx, ry]) =>
-    svg.appendChild(createEllipse(cx, cy, rx, ry)),
-  );
+  def.polygons?.forEach((pts) => {
+    const poly = createPolygon(pts);
+    poly.classList.add('image-map-shape');
+    svg.appendChild(poly);
+  });
+
+  def.rects?.forEach(([x, y, w, h]) => {
+    const rect = createRect(x, y, w, h);
+    rect.classList.add('image-map-shape');
+    svg.appendChild(rect);
+  });
+
+  def.ellipses?.forEach(([cx, cy, rx, ry]) => {
+    const ell = createEllipse(cx, cy, rx, ry);
+    ell.classList.add('image-map-shape');
+    svg.appendChild(ell);
+  });
 
   return svg;
 }


### PR DESCRIPTION
## Summary
- ensure each polygon, rect, and ellipse has the `image-map-shape` CSS class when creating an overlay
- rebuild `dist/imageMap.js`

## Testing
- `npm run build`