### PR TITLE
Add Jest tests for overlay overlayImage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  testMatch: ['**/tests/**/*.test.ts']
+};

--- a/package.json
+++ b/package.json
@@ -3,10 +3,15 @@
   "version": "0.1.0",
   "description": "Overlay images with interactive SVG vectors in Obsidian notes.",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "test": "jest"
   },
   "devDependencies": {
     "obsidian": "^1.0.0",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "@types/jest": "^29.0.0",
+    "jsdom": "^22.0.0"
   }
 }

--- a/src/imageMap.ts
+++ b/src/imageMap.ts
@@ -93,3 +93,25 @@ export function shapesToSVG(def: ShapeCoords): SVGSVGElement {
 
   return svg;
 }
+
+/**
+ * Wrap the image in a container and append an SVG overlay.
+ */
+export function overlayImage(
+  img: HTMLImageElement,
+  coords: ShapeCoords,
+  externalSvg?: string,
+): HTMLDivElement {
+  const wrapper = document.createElement('div');
+  wrapper.classList.add('image-map-container');
+  img.parentElement?.insertBefore(wrapper, img);
+  wrapper.appendChild(img);
+
+  const overlayEl = document.createElement('div');
+  overlayEl.classList.add('image-map-overlay');
+  if (externalSvg) overlayEl.innerHTML = externalSvg;
+  overlayEl.appendChild(shapesToSVG(coords));
+  wrapper.appendChild(overlayEl);
+
+  return wrapper;
+}

--- a/tests/overlayImage.test.ts
+++ b/tests/overlayImage.test.ts
@@ -1,0 +1,21 @@
+import { overlayImage, ShapeCoords } from '../src/imageMap';
+
+describe('overlayImage', () => {
+  test('wraps img in container and inserts overlay', () => {
+    document.body.innerHTML = '<div id="root"><img id="img" /></div>';
+    const img = document.getElementById('img') as HTMLImageElement;
+    const coords: ShapeCoords = { polygons: ['0,0 10,0 0,10'] };
+
+    overlayImage(img, coords);
+
+    const root = document.getElementById('root') as HTMLElement;
+    const wrapper = root.firstElementChild as HTMLElement;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper.classList.contains('image-map-container')).toBe(true);
+    expect(wrapper.contains(img)).toBe(true);
+
+    const overlay = wrapper.querySelector('.image-map-overlay');
+    expect(overlay).not.toBeNull();
+    expect(overlay?.querySelector('svg')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add `overlayImage` helper to wrap images and insert overlays
- setup Jest + JSDOM
- test that `overlayImage` inserts SVG overlay and wraps the image
- wire `npm test` command

## Testing
- `npm test` *(fails: jest not found)*