### PR TITLE
Add dry-run support to setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,12 +4,36 @@
 # File: setup.sh
 # Purpose: Set up the project by installing dependencies and
 #          building the Image Map plugin.
-# Dependencies: bash, npm, and optional Codex for network setup.
+#
+# Dependencies:
+#   - bash
+#   - npm
+#   - Node.js (>=18)
+#   - optional Codex for network setup
+#
 # Output: dist/ directory populated with compiled assets.
 # =========================================================
 
 
 set -euo pipefail
+
+# Parse flags
+dry_run=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)
+      dry_run=true
+      ;;
+  esac
+done
+
+# Helper to run commands or echo when dry running
+run() {
+  echo "+ $*"
+  if [[ "$dry_run" != true ]]; then
+    "$@"
+  fi
+}
 
 # === CONFIGURATION ===
 # Optional: request network access in Codex environments
@@ -20,8 +44,8 @@ if [[ -n "${CODEX_ENABLE_NETWORK:-}" ]]; then
 fi
 
 # === MAIN EXECUTION ===
-npm install
-npm run build
+run npm install
+run npm run build
 
 # === CLEANUP ===
 # Nothing to clean up


### PR DESCRIPTION
## Summary
- expand header with node version details
- add dry-run flag logic
- use helper `run` function for commands

## Testing
- `npm test` *(fails: jest not found)*