### PR TITLE
Add coordinates overlay support

### DIFF
--- a/src/imageMap.ts
+++ b/src/imageMap.ts
@@ -126,7 +126,7 @@ export function shapesToSVG(def: ShapeCoords): SVGSVGElement {
  */
 export function overlayImage(
   img: HTMLImageElement,
-  coords: ShapeCoords,
+  coords?: ShapeCoords | null,
   externalSvg?: string,
 ): HTMLDivElement {
   const wrapper = document.createElement('div');
@@ -137,7 +137,12 @@ export function overlayImage(
   const overlayEl = document.createElement('div');
   overlayEl.classList.add('image-map-overlay');
   if (externalSvg) overlayEl.innerHTML = externalSvg;
-  overlayEl.appendChild(shapesToSVG(coords));
+  if (
+    coords &&
+    (coords.polygons?.length || coords.rects?.length || coords.ellipses?.length)
+  ) {
+    overlayEl.appendChild(shapesToSVG(coords));
+  }
   wrapper.appendChild(overlayEl);
 
   return wrapper;

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import { Plugin } from 'obsidian';
 import ImageContextMenu from './contextMenu';
 import {
   parseCoordinates,
-  shapesToSVG,
+  overlayImage,
   ShapeCoords,
 } from './imageMap';
 
@@ -52,14 +52,7 @@ export default class ImageMapPlugin extends Plugin {
 
         if (!externalSvg && !coords) continue;
 
-        const wrapper = createDiv({ cls: 'image-map-container' });
-        img.parentElement?.insertBefore(wrapper, img);
-        wrapper.appendChild(img);
-
-        const overlayEl = createDiv({ cls: 'image-map-overlay' });
-        if (externalSvg) overlayEl.innerHTML = externalSvg;
-        if (coords) overlayEl.appendChild(shapesToSVG(coords));
-        wrapper.appendChild(overlayEl);
+        overlayImage(img, coords, externalSvg);
       }
     });
 


### PR DESCRIPTION
## Summary
- parse coordinate shapes for images
- generate overlays only when shapes exist
- reuse overlay helper in main plugin