### PR TITLE
Add CSS for editing states

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,6 @@
 /* Styles for the image-map wrapper and overlay elements.
  * Obsidian uses these rules to position interactive vectors over images. */
+/* Container around the image. Override to change layout. */
 .image-map-container {
   position: relative;
   display: inline-block;
@@ -7,6 +8,7 @@
 .image-map-container img {
   display: block;
 }
+/* Overlay element containing interactive shapes. Customize for your theme. */
 .image-map-overlay {
   position: absolute;
   top: 0;
@@ -17,9 +19,11 @@
 }
 
 /* Editor styles */
+/* Container for editor and image preview. */
 .image-map-editor-container {
   position: relative;
 }
+/* Full-size SVG canvas used while editing. */
 
 .image-map-editor {
   position: absolute;
@@ -29,15 +33,36 @@
   height: 100%;
 }
 
+/* Default appearance for drawn shapes. */
 .image-map-shape {
   fill: rgba(0, 0, 255, 0.2);
   stroke: blue;
   stroke-width: 0.5;
 }
 
+/* Small circles used as drag handles. */
 .image-map-handle {
   fill: #fff;
   stroke: blue;
   stroke-width: 0.5;
   cursor: pointer;
+}
+/* Editable shape outline. Override `.image-map-shape.is-editing` in your theme. */
+.image-map-shape.is-editing {
+  stroke-dasharray: 3;
+}
+
+/* Hover effect for shapes to indicate interactivity. */
+.image-map-shape:hover {
+  fill: rgba(0, 0, 255, 0.3);
+}
+
+/* Selected drag handle during editing. */
+.image-map-handle.is-selected {
+  fill: blue;
+}
+
+/* Hover effect for drag handles. */
+.image-map-handle:hover {
+  fill: #e0e0ff;
 }


### PR DESCRIPTION
## Summary
- document selectors in `styles.css` so themes can override them
- add hover and selection styles for shapes and handles

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461e417a8083229e33d2734136696d